### PR TITLE
handle matlab silent dropped connections and corrupted downloads

### DIFF
--- a/Allsky/dlFITS.m
+++ b/Allsky/dlFITS.m
@@ -1,4 +1,4 @@
-function dlFITS(final_dir,times,varargin)
+function badfiles = dlFITS(final_dir,times,varargin)
 % dlFITS
 % by John Swoboda
 % This function will find the DASC data within a certain time period and down it
@@ -36,28 +36,71 @@ if nfile > 1000
     warning(['Attempting to download ',int2str(nfile),' files, this may take a long time and use a lot of Hard drive space.'])
 end
 
+badfiles = {};
+
 for k = 1:nfile
     temp_url = [urlstem,red_file_list{k}];
     temp_fileput = fullfile(final_dir,red_file_list{k});
 
     updatestr = [red_file_list{k},' ', int2str(k),' / ',int2str(nfile)];
+
+    trynum=1;
+    
     if exist(temp_fileput,'file')
-        disp(['skipping already existing ',updatestr])
+        badfile = verfits(temp_url,temp_fileput,trynum);
+        if badfile
+            badfiles{end+1} = temp_fileput; %#ok<AGROW>
+        end
         continue
     else
         disp(['downloading ',updatestr])
     end
 
+
     try
-        try
-            websave(temp_fileput,temp_url,'Timeout',30);
-        catch
-            urlwrite(temp_url,temp_fileput);
-        end
+        grabfile(temp_url,temp_fileput,trynum)
     catch
         disp(['problem downloading ',temp_url])
     end
     pause(0.5+0.5*rand(1)) %random delay of 0.5-1.0 second to avoid getting banned
 end %for
 
+if ~isempty(badfiles)
+    warning(['could not download ',int2str(length(badfiles)),' files.'])
+    disp(badfiles)
+end
+
+end %function
+
+function badfile = grabfile(temp_url,temp_fileput,trynum)      
+    try
+        websave(temp_fileput,temp_url,'Timeout',30);
+    catch
+        urlwrite(temp_url,temp_fileput);
+    end
+    
+    badfile = verfits(temp_url,temp_fileput,trynum);
+end %function
+
+function badfile = verfits(temp_url,temp_fileput,trynum)
+    
+    % partially verify download by seeing if 512x512 pixel image was truncated
+    %finf = fitsinfo(temp_fileput);
+    %finf.PrimaryData.Keywords
+    try
+        fitsread(temp_fileput,'PixelRegion',{512,512}); 
+        badfile = false;
+    catch err
+        trynum = trynum+1;
+        disp(err.message)
+        warning(['download ',temp_fileput,' failed, retrying'])
+        if trynum<=3
+            pause(0.5) %don't wildly recycle
+            badfile = grabfile(temp_url,temp_fileput,trynum);
+        else
+            warning(['tried 3 times to download ',temp_url,' , giving up!'])
+            badfile=true;
+        end
+    end
+    
 end %function

--- a/Example_Scripts/loadDASC2013Apr14.m
+++ b/Example_Scripts/loadDASC2013Apr14.m
@@ -3,4 +3,4 @@ addpath(genpath('..'));
 outdir=tempdir;
 timefirstlast={'12-Jan-2015 08:00:00','12-Jan-2015 09:00:00'};
 
-dlFITS(outdir,timefirstlast);
+badfiles = dlFITS(outdir,timefirstlast);


### PR DESCRIPTION
added recursive check/retry download to handle iffy connections from AMISR server, which unlike Python Matlab just fails silently.
